### PR TITLE
Compute mean in combine_scoresheets.py

### DIFF
--- a/combine_scoresheets.py
+++ b/combine_scoresheets.py
@@ -20,6 +20,7 @@ def combine_scores(input_folder: Path, output_file: Path, player_group_lookup_fi
     Args:
         input_folder: Directory containing individual evaluator CSVs
         output_file: Path for combined output CSV
+        player_group_lookup_file: Path for a 2-column CSV of player evaluation groups
         evaluation_columns: List of column names to process
         include_header: Whether to include a header row in the output
     """
@@ -40,6 +41,11 @@ def combine_scores(input_folder: Path, output_file: Path, player_group_lookup_fi
 
     aggregated_df = combined_df.groupby('Player').agg({
         col: lambda x: ','.join(x.dropna().astype(str))
+        for col in evaluation_columns
+    }).reset_index()
+
+    aggregated_df = combined_df.groupby('Player').agg({
+        col: 'mean'
         for col in evaluation_columns
     }).reset_index()
 

--- a/process_scoresheets.py
+++ b/process_scoresheets.py
@@ -52,7 +52,7 @@ def _validate_scores(evaluation_columns: List[str], min_score: int, max_score: i
     scores = row["scores"]
 
     num_expected_columns = len(evaluation_columns)
-    if len(scores) != num_expected_columns:
+    if len(scores) < num_expected_columns:
         log_msg = f"Evaluator {evaluator_name} is missing scores for player {player_name} -- please add them manually."
         logger.warning(log_msg)
         scores: List[Optional[float]] = [None] * num_expected_columns
@@ -269,7 +269,8 @@ def parse_args() -> argparse.Namespace:
         "--evaluation-columns",
         type=str,
         nargs="+",
-        required=True,
+        default=DEFAULT_EVAL_COLUMNS,
+        required=False,
         help="Space-separated list of evaluation criteria (e.g., 'Throwing Catching Athleticism')"
     )
 


### PR DESCRIPTION
Previously, we would simply do string concatenation in `combine_scores.py` which had the effect of producing a final spreadsheet that showed evaluators' raw scores for each dimension. With this change, we now compute a mean, such that we upload a single value per cell into our final spreadsheet.

This also makes the `--evaluation-columns` parameter optional, and modifies score validation to only report missing scores when the number of processed scores is smaller than the set of expected scores.